### PR TITLE
Add z/OS support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ This is supported and tested on the following:
 * Fedora 42 and 43
 * Alma Linux 8, 9 and 10 (Should be equivalent to RHEL)
 * Alpine Linux 3.20 through 3.23
+* z/OS 2.5 or newer (needs asyncinotify_zos helper package)
 
 We regularly remove out-of-support OSes from the tests and add new releases.
 

--- a/src/asyncinotify/__init__.py
+++ b/src/asyncinotify/__init__.py
@@ -60,15 +60,15 @@ class InitFlags(IntFlag):
 
     __slots__ = ()
 
-    #: Set the close-on-exec (FD_CLOEXEC) flag on the new file descriptor.  See
-    #: the description of the O_CLOEXEC flag in  open(2)  for  reasons why this
+    #: Set the close-on-exec (FD_CLOEXEC) flag on the new file descriptor if it exists.
+    #: See the description of the O_CLOEXEC flag in  open(2)  for  reasons why this
     #: may be useful.
-    CLOEXEC = os.O_CLOEXEC
+    CLOEXEC = getattr(os, 'O_CLOEXEC', 0)
 
-    #: Set the O_NONBLOCK file status flag on the open file description (see
+    #: Set the O_NONBLOCK file status flag on the open file description if it exists (see
     #: open(2)) referred to by the new file descriptor.  Using this flag saves
     #: extra calls to fcntl(2) to achieve the same result.
-    NONBLOCK = os.O_NONBLOCK
+    NONBLOCK = getattr(os, 'O_CLOEXEC', 0)
 
 
 class Mask(IntFlag):

--- a/src/asyncinotify/__init__.py
+++ b/src/asyncinotify/__init__.py
@@ -641,7 +641,7 @@ class Inotify:
         '''
         if not self._events:
             if self.sync_timeout is not None:
-                if not self._selector.poll(self.sync_timeout, 1):
+                if not self._selector.select(self.sync_timeout):
                     return None
             future = _FakeFuture()
             self._get(future)

--- a/src/asyncinotify/__init__.py
+++ b/src/asyncinotify/__init__.py
@@ -21,7 +21,7 @@ from warnings import warn
 import weakref
 from weakref import ReferenceType
 from asyncio import Future
-import select
+import selectors
 from collections import deque
 
 # Python 3.7 suggests get_running_loop for library code
@@ -411,11 +411,11 @@ class Inotify:
         full-sized.
 
     :param sync_timeout: If this is not None, then sync_get will wait on an
-        epoll call for that long, and return None on a timeout.  Normal
+        selector call for that long, and return None on a timeout.  Normal
         iteration will also exit on a timeout.
     '''
 
-    __slots__ = ('_fd', '_watches', '_events', '_epoll', '_sync_timeout', '_cache_size', '__weakref__')
+    __slots__ = ('_fd', '_watches', '_events', '_selector', '_sync_timeout', '_cache_size', '__weakref__')
 
     def __init__(self,
                  flags: InitFlags = InitFlags.CLOEXEC | InitFlags.NONBLOCK,
@@ -429,8 +429,8 @@ class Inotify:
         self._watches: Dict[int, Watch] = {}
 
         self._events: List[Event] = []
-        self._epoll: select.epoll = select.epoll()
-        self._epoll.register(fd, select.EPOLLIN)
+        self._selector: selectors.DefaultSelector = selectors.DefaultSelector()
+        self._selector.register(fd, selectors.EVENT_READ)
         self.sync_timeout = sync_timeout
 
     @property
@@ -537,7 +537,7 @@ class Inotify:
         '''
         self.sync_timeout = None
         if self._fd is not None:
-            self._epoll.close()
+            self._selector.close()
             os.close(self._fd)
             self._fd = None
 
@@ -641,7 +641,7 @@ class Inotify:
         '''
         if not self._events:
             if self.sync_timeout is not None:
-                if not self._epoll.poll(self.sync_timeout, 1):
+                if not self._selector.poll(self.sync_timeout, 1):
                     return None
             future = _FakeFuture()
             self._get(future)

--- a/src/asyncinotify/_ffi.py
+++ b/src/asyncinotify/_ffi.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 import os
 
-if (os.uname().sysname.lower() in {'linux', 'freebsd'}) and os.environ.get('READTHEDOCS', 'false').lower() != 'true':
+if (os.uname().sysname.lower() in {'linux', 'freebsd', 'os/390'}) and os.environ.get('READTHEDOCS', 'false').lower() != 'true':
     import ctypes
     import ctypes.util
 
@@ -41,6 +41,15 @@ if (os.uname().sysname.lower() in {'linux', 'freebsd'}) and os.environ.get('READ
         if inotify_path:
             return inotify_path
 
+        # z/OS UNIX
+        try:
+            import asyncinotify_zos  # noqa
+            libzosinotify = ctypes.CDLL(None)
+            if hasattr(libzosinotify, "inotify_init"):
+                return None
+        except ImportError:
+            pass
+
         raise RuntimeError("inotify support was not found")    
     
     def check_return(value: int) -> int:
@@ -68,4 +77,4 @@ if (os.uname().sysname.lower() in {'linux', 'freebsd'}) and os.environ.get('READ
     libc.inotify_rm_watch.argtypes = (ctypes.c_int, ctypes.c_int)
 else:
     import warnings
-    warnings.warn('inotify is a Linux and FreeBSD API.  You can package this library on other platforms, but not run it.')
+    warnings.warn('inotify is a Linux, FreeBSD or z/OS API.  You can package this library on other platforms, but not run it.')


### PR DESCRIPTION
z/OS is a OS developed by IBM for the Z Architecture that runs the Mainframes (do not confuse with z/Linux, which is a standard GNU/Linux distro running on Z hardware). z/OS includes a POSIX-compliant UNIX environment called "z/OS UNIX".

Recently, IBM implemented some of the Linux Kernel subsystems, such as inotify, in z/OS UNIX ([PH45182](https://public.dhe.ibm.com/systems/z/zos/PH45182.pdf)). All the APIs are 100% compatible with those found in Linux or FreeBSD. This PR brings support for z/OS to use inotify from Python.

This PR is split in three parts:

- The first one is abount using DefaultSelector instead of epoll. This is needed because in z/OS epoll is not yet available. Using DefaultSelector will use the most efficient implementation available on the current platform.
- The second one adds z/OS support. Due to z/OS-specific DLL constraints, a tiny wrapper written in C is needed. To keep asyncinotify 100% Python, a helper package called "asyncinotify_zos" is imported instead of directly loading the DLL. 
- The last one is about the docs changes to reflect the new support.

I’m happy to adjust the approach if you prefer a different structure.