### PR TITLE
Use weakref.finalize instead of __del__

### DIFF
--- a/src/asyncinotify/__init__.py
+++ b/src/asyncinotify/__init__.py
@@ -432,6 +432,7 @@ class Inotify:
         self._selector: selectors.DefaultSelector = selectors.DefaultSelector()
         self._selector.register(fd, selectors.EVENT_READ)
         self.sync_timeout = sync_timeout
+        self._finalizer = weakref.finalize(self, self.close)
 
     @property
     def sync_timeout(self) -> Optional[float]:
@@ -518,9 +519,6 @@ class Inotify:
         return self
 
     def __exit__(self, *args, **kwargs) -> None:
-        self.close()
-
-    def __del__(self) -> None:
         self.close()
 
     def close(self) -> None:


### PR DESCRIPTION
Noticed a few warnings in the test suite for Home Assistant. The issue seems to be that it's not deterministic when `__del__` will actually be called. Especially with async tests (via `pytest-asyncio`) this can create problems. After looking at the [Python docs](https://docs.python.org/3/reference/datamodel.html#object.__del__), they especially recommend to use `weakref.finalize` instead of `__del__` to do any cleanups.

> It is not guaranteed that \_\_del__() methods are called for objects that still exist when the interpreter exits. [weakref.finalize](https://docs.python.org/3/library/weakref.html#weakref.finalize) provides a straightforward way to register a cleanup function to be called when an object is garbage collected.

```py
  /.../venv/lib/python3.14/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning:
    Exception ignored while calling deallocator <function Inotify.__del__ at 0x7ff27010e560>: None
  
  Traceback (most recent call last):
    File "/.../venv/lib/python3.14/site-packages/asyncinotify/__init__.py", line 524, in __del__
      self.close()
      ~~~~~~~~~~^^
    File "/.../venv/lib/python3.14/site-packages/asyncinotify/__init__.py", line 539, in close
      if self._fd is not None:
         ^^^^^^^^
  AttributeError: 'asyncinotify.Inotify' object has no attribute '_fd'. Did you mean: 'fd'?
```